### PR TITLE
Add tryWait() to Child class

### DIFF
--- a/kommand-core/kommand_core.h
+++ b/kommand-core/kommand_core.h
@@ -103,6 +103,8 @@ unsigned int id_child(const void *child);
 
 struct IntResult wait_child(const void *child);
 
+struct IntResult try_wait_child(const void *child);
+
 /**
  * The returned [Output] will empty
  * if convert the [Child.stdout] and [Child.stderr] to buffered

--- a/kommand-core/src/bin/leaks_test.rs
+++ b/kommand-core/src/bin/leaks_test.rs
@@ -2,14 +2,14 @@ use std::ffi::{c_char, c_ulonglong};
 
 use kommand_core::ffi_util::{as_cstring, into_string};
 use kommand_core::io::{drop_stdout, read_line_stdout};
-use kommand_core::process::{buffered_stdout_child, Stdio};
+use kommand_core::process::{buffered_stdout_child, try_wait_child, Stdio};
 use kommand_core::process::{drop_child, wait_child};
 use kommand_core::process::{drop_command, new_command, spawn_command, stdout_command};
 use kommand_core::result::ErrorType;
 
 fn main() {
     unsafe {
-        (0..1).for_each(|i| {
+        (0..100).for_each(|i| {
             let command = new_command(as_cstring("target/debug/kommand-echo").as_ptr());
             // arg_command(command, as_cstring("echo").as_ptr());
             stdout_command(command, Stdio::Pipe);
@@ -20,6 +20,12 @@ fn main() {
                 drop_command(command);
                 panic!("{}", into_string(result.err))
             };
+
+            if try_wait_child(child).ok == -2 {
+                println!("Child is not finished");
+            } else {
+                println!("Child is finished");
+            }
 
             let stdout = buffered_stdout_child(child);
             if stdout.is_null() {
@@ -44,6 +50,11 @@ fn main() {
             }
 
             wait_child(child);
+            let status = try_wait_child(child);
+            if status.ok < 0 {
+                drop_command(command);
+                panic!("No proper status code returned: {}", status.ok);
+            }
             drop_stdout(stdout);
             drop_child(child);
             drop_command(command);

--- a/kommand-core/src/process/child.rs
+++ b/kommand-core/src/process/child.rs
@@ -68,6 +68,12 @@ pub extern "C" fn wait_child(mut child: *const c_void) -> IntResult {
     child.wait().into()
 }
 
+#[no_mangle]
+pub extern "C" fn try_wait_child(mut child: *const c_void) -> IntResult {
+    let child = as_child_mut(&mut child);
+    child.try_wait().into()
+}
+
 /// The returned [Output] will empty
 /// if convert the [Child.stdout] and [Child.stderr] to buffered
 /// with [buffered_stdout_child] and [buffered_stderr_child]

--- a/src/commonMain/kotlin/com/kgit2/kommand/process/Child.kt
+++ b/src/commonMain/kotlin/com/kgit2/kommand/process/Child.kt
@@ -21,5 +21,8 @@ expect class Child {
     fun wait(): Int
 
     @Throws(KommandException::class)
+    fun tryWait(): Int?
+
+    @Throws(KommandException::class)
     fun waitWithOutput(): Output
 }

--- a/src/jvmMain/kotlin/com/kgit2/kommand/process/Child.jvm.kt
+++ b/src/jvmMain/kotlin/com/kgit2/kommand/process/Child.jvm.kt
@@ -5,6 +5,7 @@ import com.kgit2.kommand.exception.KommandException
 import com.kgit2.kommand.io.BufferedReader
 import com.kgit2.kommand.io.BufferedWriter
 import com.kgit2.kommand.io.Output
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 
 actual class Child(
@@ -43,6 +44,14 @@ actual class Child(
     actual fun wait(): Int {
         stdin.get()?.close()
         return process.waitFor()
+    }
+
+    @Throws(KommandException::class)
+    actual fun tryWait(): Int? {
+        return when (process.waitFor(0, TimeUnit.MICROSECONDS)) {
+            true -> wait()
+            false -> return null
+        }
     }
 
     @Throws(KommandException::class)

--- a/src/jvmMain/kotlin/com/kgit2/kommand/process/Child.jvm.kt
+++ b/src/jvmMain/kotlin/com/kgit2/kommand/process/Child.jvm.kt
@@ -50,7 +50,7 @@ actual class Child(
     actual fun tryWait(): Int? {
         return when (process.waitFor(0, TimeUnit.MICROSECONDS)) {
             true -> wait()
-            false -> return null
+            false -> null
         }
     }
 

--- a/src/nativeMain/kotlin/com/kgit2/kommand/Extension.kt
+++ b/src/nativeMain/kotlin/com/kgit2/kommand/Extension.kt
@@ -9,12 +9,7 @@ import kommand_core.drop_output
 import kommand_core.drop_string
 import kommand_core.into_output
 import kommand_core.void_to_string
-import kotlinx.cinterop.ByteVar
-import kotlinx.cinterop.CPointer
-import kotlinx.cinterop.CValue
-import kotlinx.cinterop.memScoped
-import kotlinx.cinterop.pointed
-import kotlinx.cinterop.toKString
+import kotlinx.cinterop.*
 
 fun CPointer<ByteVar>.asString(): String {
     val result = this.toKString()
@@ -50,6 +45,15 @@ fun Output.Companion.from(result: CValue<kommand_core.VoidResult>): Output = mem
         )
         drop_output(output)
         newOutput
+    }
+}
+
+fun Int.Companion.fromOptional(result: CValue<kommand_core.IntResult>): Int? = memScoped {
+    return@memScoped if (result.ptr.pointed.ok == -2) {
+        // Application still running
+        null
+    } else {
+        Int.Companion.from(result)
     }
 }
 

--- a/src/nativeMain/kotlin/com/kgit2/kommand/process/Child.native.kt
+++ b/src/nativeMain/kotlin/com/kgit2/kommand/process/Child.native.kt
@@ -65,7 +65,8 @@ actual class Child(
 
     @Throws(KommandException::class)
     actual fun tryWait(): Int? {
-        return when (Int.fromOptional(try_wait_child(inner))) {
+        val result = Int.fromOptional(try_wait_child(inner))
+        return when (result) {
             null -> null
             else -> wait()
         }


### PR DESCRIPTION
I added an implementation of `tryWait()` method to `Child` class. It more-or-less follows the semantics of `try_wait()` from Rust:

* if the process is still running, it returns `null`
* otherwise, it returns the exit status

Please let me know if the coding style is appropriate for your project.